### PR TITLE
Fix dark theme styling

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -33,10 +33,6 @@ pre {
     border: 1px solid gray;
     padding: 0.5em;
   }
-  code {
-    background-color: #1e1e1e;
-    padding: 0.25em;
-  }
   .diff0 {
     color: #ff613c;
   }


### PR DESCRIPTION
This change deletes css that caused problems with dark theme. The problems:

1. The background of code in code blocks cover the overhanging text above it
2. It throws off the monospace alignment of the first line of code blocks

Before:
<img width="589" alt="Screenshot 2023-08-22 at 8 15 29 PM" src="https://github.com/andrewrk/andrewkelley.me/assets/8485687/f2e512c0-70ee-4224-9bc3-ef5476874bf3">

After:
<img width="587" alt="Screenshot 2023-08-22 at 8 15 06 PM" src="https://github.com/andrewrk/andrewkelley.me/assets/8485687/63913583-5ed0-4ca7-b703-9cab773e1d0d">

(Code block from https://andrewkelley.me/post/js-callback-organization.html)

Look at the "g", ",", and "{" characters get cut off at the bottom to see the over hanging text for problem 1. Look at how the first line is not aligned with the second line for problem 2.

Technically this changes how inline code looks too:

Before:
<img width="263" alt="Screenshot 2023-08-22 at 8 23 08 PM" src="https://github.com/andrewrk/andrewkelley.me/assets/8485687/76388a07-870d-49b5-8fed-15a15cf11cb1">

After:
<img width="257" alt="Screenshot 2023-08-22 at 8 23 38 PM" src="https://github.com/andrewrk/andrewkelley.me/assets/8485687/069402a0-476e-4e12-b5f2-dfe1806d67a8">

Personally I think this is fine since light theme does not attempt to style inline code. But maybe you actually meant to apply styles to both dark and light theme inline code?

Loving your work. Keep it up!